### PR TITLE
parallelTargets: 2 -> 8 (issue RPT-3193)

### DIFF
--- a/fanout.js
+++ b/fanout.js
@@ -31,7 +31,7 @@ var async = require('async');
 
 // Service configuration
 var config = {
-	parallelTargets    : 2,    // Number of parallel targets for fan-out destination
+	parallelTargets    : 8,    // Number of parallel targets for fan-out destination
 	parallelPosters    : 2,    // Number of parallel posters for fan-out destination
 	debug              : false // Activate debug messages
 };


### PR DESCRIPTION
in the raw use case, we're fanning out to 12+ targets.  per discussion
in the NB status meeting this morning, there doesn't seem to be any
reason not to move in the direction of having this value be larger
than the number of targets.  however, to be cautious, we've moving in
smaller increments for now; this is the first such increment.
    
the main worry is that we might suddenly exhaust the memory allocated
to the lambda, and we've recently quadrupled that setting, so that's
the factor we're starting with here as well.