### PR TITLE
Disable publication of custom cloudwatch metrics

### DIFF
--- a/fanout.js
+++ b/fanout.js
@@ -127,15 +127,12 @@ function interceptService(serviceReference, target, event, callback) {
 
 //********
 // This function manages the messages for a target
-function sendMessages(eventSourceARN, target, event, stats, callback) {
+function sendMessages(eventSourceARN, target, event, callback) {
   if(config.debug) {
     console.log("Processing target '" + target.id + "'");
   }
 
   var start = Date.now();
-  stats.addTick('targets#' + eventSourceARN);
-  stats.register('records#' + eventSourceARN + '#' + target.destination, 'Records', 'stats', 'Count', eventSourceARN, target.destination);
-  stats.addValue('records#' + eventSourceARN + '#' + target.destination, event.Records.length);
 
   async.waterfall([
       function(done) { services.get(target, done); },
@@ -175,7 +172,7 @@ function sendMessages(eventSourceARN, target, event, stats, callback) {
 
 //********
 // This function reads a set of records from Amazon Kinesis or Amazon DynamoDB Streams and sends it to all subscribed parties
-function fanOut(eventSourceARN, event, context, targets, stats, callback) {
+function fanOut(eventSourceARN, event, context, targets, callback) {
   if(targets.length === 0) {
     console.log("No output subscribers found for this event");
     callback(null);
@@ -186,7 +183,7 @@ function fanOut(eventSourceARN, event, context, targets, stats, callback) {
   var hasErrors    = false;
 
   var queue = async.queue(function(target, done) {
-    sendMessages(eventSourceARN, target, event, stats, done);
+    sendMessages(eventSourceARN, target, event, done);
   }, config.parallelTargets);
 
   queue.drain = function() {
@@ -244,7 +241,7 @@ exports.handler = function(event, context) {
   var queue = async.queue(function(eventSourceARN, callback) {
     async.waterfall([
         function(done) {  configuration.get(eventSourceARN, services.definitions, done); },
-        function(targets, done) {  fanOut(eventSourceARN, sources[eventSourceARN], context, targets, stats, done); }
+        function(targets, done) {  fanOut(eventSourceARN, sources[eventSourceARN], context, targets, done); }
       ],
       callback);
   });

--- a/fanout.js
+++ b/fanout.js
@@ -43,7 +43,7 @@ services.configure(config);
 // This function posts data to the specified service
 //  If the target is marked as 'collapse', records will
 //  be grouped in a single payload before being sent
-function postToService(serviceReference, target, records, stats, callback) {
+function postToService(serviceReference, target, records, callback) {
 	var parallelPosters = target.parallel ? config.parallelPosters : 1;
 	var errors = [];
   var definition = serviceReference.definition;
@@ -118,7 +118,7 @@ function postToService(serviceReference, target, records, stats, callback) {
 
 //********
 // This function transfers an entire event to the underlying service
-function interceptService(serviceReference, target, event, stats, callback) {
+function interceptService(serviceReference, target, event, callback) {
   serviceReference.definition.intercept(serviceReference.service, target, event, function(err) {
     serviceReference.dispose();
     callback(err);
@@ -145,14 +145,14 @@ function sendMessages(eventSourceARN, target, event, stats, callback) {
           if(target.passthrough) {
             transformation.transformRecords(event.Records, target, function(err, transformedRecords) {
               transformedRecords.forEach(function(record) { record.data = record.data.toString('base64') });
-              interceptService(serviceReference, target, { Records: transformedRecords }, stats, done);
+              interceptService(serviceReference, target, { Records: transformedRecords }, done);
             });
           } else {
-            interceptService(serviceReference, target, event, stats, done);
+            interceptService(serviceReference, target, event, done);
           }
         } else if (definition.send) {
           transformation.transformRecords(event.Records, target, function(err, transformedRecords) {
-            postToService(serviceReference, target, transformedRecords, stats, done);
+            postToService(serviceReference, target, transformedRecords, done);
           });
         } else {
           done(new Error("Invalid module '" + target.type + "', it must export either an 'intercept' or a 'send' method"));


### PR DESCRIPTION
The fanouter’s cloudwatch metrics are too voluminous in production, so they’re being throttled.

We don’t think this throttling is impacting performance, but we can’t be sure, and anyway it’s definitely cluttering up the logs.  We’re not seeing any valuable information from these metrics when they’re not throttled.  So, just disable them.